### PR TITLE
feat: security 관련 주석, baseEntity 어노테이션 추가, 작성 테스트 확인 및 리스트는 아직..

### DIFF
--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/IjoaApplication.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/IjoaApplication.java
@@ -2,7 +2,9 @@ package com.shinhan.shbhack.ijoa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing // BaseEntity의 자동 시간 지정이 안되서 더 추가함
 @SpringBootApplication
 public class IjoaApplication {
 

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/DiaryController.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/DiaryController.java
@@ -1,10 +1,33 @@
 package com.shinhan.shbhack.ijoa.api.controller.diary;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.shinhan.shbhack.ijoa.api.controller.diary.requestdto.DiaryCreateRequest;
+import com.shinhan.shbhack.ijoa.api.service.diary.command.DiaryService;
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.request.DiaryCreateServiceRequest;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.Diary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/diaries")
+@RequiredArgsConstructor
 public class DiaryController {
+    private final DiaryService diaryService;
+    @PostMapping("")
+    public ResponseEntity<?> writeDiary(@RequestBody DiaryCreateRequest diaryCreateRequest){
 
+        diaryService.writeDiary(new DiaryCreateServiceRequest(diaryCreateRequest));
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/list/{memberId}")
+    public ResponseEntity<?> listDiary(@PathVariable Long memberId){
+        List<Diary> result = diaryService.listDiary(memberId);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/requestdto/DiaryCreateRequest.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/requestdto/DiaryCreateRequest.java
@@ -2,14 +2,26 @@ package com.shinhan.shbhack.ijoa.api.controller.diary.requestdto;
 
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
 public class DiaryCreateRequest {
+    private String memberId;
+    private String title;
+    private String emotion;
+    private String content;
+    private LocalDate date;
+    private List<MultipartFile> photo;
 
 
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/command/DiaryService.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/command/DiaryService.java
@@ -1,14 +1,56 @@
 package com.shinhan.shbhack.ijoa.api.service.diary.command;
 
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.request.DiaryCreateServiceRequest;
+import com.shinhan.shbhack.ijoa.common.util.file.FileStore;
+import com.shinhan.shbhack.ijoa.common.util.file.UploadFile;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.Diary;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryImage;
+import com.shinhan.shbhack.ijoa.domain.diary.repository.datajpa.DiaryRepository;
+import com.shinhan.shbhack.ijoa.domain.diary.repository.query.DiaryQueryRepository;
+import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
+import com.shinhan.shbhack.ijoa.domain.member.repository.datajpa.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class DiaryService {
+    private final DiaryRepository diaryRepository;
+    private final DiaryQueryRepository diaryQueryRepository;
+    private final MemberRepository memberRepository;
+    private final FileStore fileStore;
+    public void writeDiary(DiaryCreateServiceRequest diaryCreateServiceRequest){
+        try{
+            Long memberId = Long.parseLong(diaryCreateServiceRequest.getMemberId());
+            log.info(memberId.toString());
+            Member member = memberRepository.findById(memberId).orElseThrow(()->new RuntimeException("유저 아이디로 멤버 찾기 실패"));
+            Diary newDiary = Diary.of(diaryCreateServiceRequest, member); // 일기장 생성
 
+            List<UploadFile> fileInfos = fileStore.storeFiles(diaryCreateServiceRequest.getPhoto());
+            List<DiaryImage> diaryImageList = new ArrayList<>();
+            for(UploadFile uploadFile : fileInfos){
+                diaryImageList.add(DiaryImage.of(uploadFile, newDiary));
+            } // 다이어리 이미지 객체 생성
+            newDiary.setImages(diaryImageList); // 다이어리에 이미지 리스트 지정
+            diaryRepository.save(newDiary);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<Diary> listDiary(Long memberId){
+        log.info("멤버 아이디: " + memberId.toString());
+
+        return diaryQueryRepository.findByMember(memberId);
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/request/DiaryCreateServiceRequest.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/request/DiaryCreateServiceRequest.java
@@ -1,13 +1,34 @@
 package com.shinhan.shbhack.ijoa.api.service.diary.dto.request;
 
+import com.shinhan.shbhack.ijoa.api.controller.diary.requestdto.DiaryCreateRequest;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
 public class DiaryCreateServiceRequest {
+    private String memberId;
+    private String title;
+    private String emotion;
+    private String content;
+    private LocalDate date;
+    private List<MultipartFile> photo;
 
+    public DiaryCreateServiceRequest(DiaryCreateRequest diaryCreateRequest) {
+        this.memberId = diaryCreateRequest.getMemberId();
+        this.title = diaryCreateRequest.getTitle();
+        this.emotion = diaryCreateRequest.getEmotion();
+        this.content = diaryCreateRequest.getContent();
+        this.date = diaryCreateRequest.getDate();
+        this.photo = diaryCreateRequest.getPhoto();
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/common/config/SecurityConfig.java
@@ -1,9 +1,9 @@
-package com.shinhan.shbhack.ijoa.common.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-}
+//package com.shinhan.shbhack.ijoa.common.config;
+//
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//
+//@Configuration
+//@EnableWebSecurity
+//public class SecurityConfig {
+//}

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/Diary.java
@@ -1,5 +1,6 @@
 package com.shinhan.shbhack.ijoa.domain.diary.entity;
 
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.request.DiaryCreateServiceRequest;
 import com.shinhan.shbhack.ijoa.domain.BaseEntity;
 import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
 import lombok.*;
@@ -17,6 +18,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = PROTECTED)
 public class Diary extends BaseEntity {
 
@@ -48,4 +50,15 @@ public class Diary extends BaseEntity {
 
     @OneToMany(mappedBy = "diary")
     private List<DiaryShare> shares;
+
+
+    public static Diary of(DiaryCreateServiceRequest diaryCreateServiceRequest, Member member){
+        Diary diary = new Diary();
+        diary.setMember(member);
+        diary.setTitle(diaryCreateServiceRequest.getTitle());
+        diary.setDiary_date(diaryCreateServiceRequest.getDate());
+        diary.setContent(diaryCreateServiceRequest.getContent());
+//        diary.setImages(images);
+        return diary;
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/DiaryImage.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/DiaryImage.java
@@ -1,8 +1,12 @@
 package com.shinhan.shbhack.ijoa.domain.diary.entity;
 
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.request.DiaryCreateServiceRequest;
+import com.shinhan.shbhack.ijoa.common.util.file.UploadFile;
+import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -12,6 +16,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class DiaryImage {
     @Id
@@ -30,4 +35,11 @@ public class DiaryImage {
     @NotNull
     private String storeFileName;
 
+    public static DiaryImage of(UploadFile fileInfos, Diary diary){
+        DiaryImage diaryImage = new DiaryImage();
+        diaryImage.setDiary(diary);
+        diaryImage.setUploadFileName(fileInfos.getUploadFileName());
+        diaryImage.setStoreFileName(fileInfos.getStoreFileName());
+        return diaryImage;
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/datajpa/DiaryRepository.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/datajpa/DiaryRepository.java
@@ -3,6 +3,8 @@ package com.shinhan.shbhack.ijoa.domain.diary.repository.datajpa;
 import com.shinhan.shbhack.ijoa.domain.diary.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/query/DiaryQueryRepository.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/query/DiaryQueryRepository.java
@@ -1,8 +1,13 @@
 package com.shinhan.shbhack.ijoa.domain.diary.repository.query;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.Diary;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.QDiary;
+import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -10,4 +15,7 @@ public class DiaryQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    public List<Diary> findByMember(Long memberID){
+        return queryFactory.selectFrom(QDiary.diary).where(QDiary.diary.member.id.eq(memberID)).fetch();
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -65,7 +65,7 @@ app:
     #emailCodeExpirationMs: 100000000
 
 file:
-  dir: /imagesss/
+  dir: C:\\Users\\ssafy\\Downloads\\
 
 
 # spring mail


### PR DESCRIPTION
## 구현 기능

-   Spring security 관련 코드를 주석처리했습니다.
-  생성, 수정 날짜가 담겨있는 BaseEntity의 날짜 정보가 자동으로 생성되지 않는 문제가 있기에 IjoaApplication에 어노테이션 추가
- 다이어리 작성은 테스트 확인했지만 리스트 목록은 QueryDSL 미숙으로 인해 작동하지 않습니다.

