### PR TITLE
feat: 일기 API 완성

### DIFF
--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/DiaryController.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/DiaryController.java
@@ -39,4 +39,23 @@ public class DiaryController {
         DiaryDetailResponse result = diaryService.readDiary(diaryId);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
+
+    @PutMapping("/{diaryId}")
+    public ResponseEntity<?> modifyDiary(@PathVariable Long diaryId, @RequestBody DiaryCreateRequest diaryCreateRequest){
+        diaryService.modifyDiary(new DiaryCreateServiceRequest(diaryCreateRequest),diaryId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<?> deleteDiary(@PathVariable Long diaryId){
+        diaryService.deleteDiary(diaryId);
+        return new ResponseEntity<>(HttpStatus.OK);
+
+    }
+
+    @PostMapping("/share/{diaryId}")
+    public ResponseEntity<?> shareDiary(@PathVariable Long diaryId){
+        diaryService.shareDiary(diaryId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/DiaryShareController.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/DiaryShareController.java
@@ -1,0 +1,31 @@
+package com.shinhan.shbhack.ijoa.api.controller.diary;
+
+import com.shinhan.shbhack.ijoa.api.controller.diary.requestdto.DiaryCreateRequest;
+import com.shinhan.shbhack.ijoa.api.service.diary.command.DiaryService;
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.request.DiaryCreateServiceRequest;
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.response.DiaryDetailResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/shareddiaries")
+@RequiredArgsConstructor
+public class DiaryShareController {
+    private final DiaryService diaryService;
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<?> readDiary(@PathVariable Long diaryId){
+
+        DiaryDetailResponse diaryDetailResponse = diaryService.readShareDiary(diaryId);
+        if(diaryDetailResponse == null){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+
+        }else{
+            return new ResponseEntity<>(diaryDetailResponse, HttpStatus.OK);
+
+        }
+    }
+}

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/requestdto/DiaryCreateRequest.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/controller/diary/requestdto/DiaryCreateRequest.java
@@ -22,6 +22,6 @@ public class DiaryCreateRequest {
     private String content;
     private LocalDate date;
     private List<MultipartFile> photo;
-
+    private MultipartFile record;
 
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/command/DiaryService.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/command/DiaryService.java
@@ -4,11 +4,15 @@ import com.shinhan.shbhack.ijoa.api.service.diary.dto.request.DiaryCreateService
 import com.shinhan.shbhack.ijoa.api.service.diary.dto.response.DiaryCalenderResponse;
 import com.shinhan.shbhack.ijoa.api.service.diary.dto.response.DiaryDetailResponse;
 import com.shinhan.shbhack.ijoa.api.service.diary.dto.response.DiaryImageResponse;
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.response.DiaryRecordResponse;
 import com.shinhan.shbhack.ijoa.common.util.file.FileStore;
 import com.shinhan.shbhack.ijoa.common.util.file.UploadFile;
 import com.shinhan.shbhack.ijoa.domain.diary.entity.Diary;
 import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryImage;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryRecord;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryShare;
 import com.shinhan.shbhack.ijoa.domain.diary.repository.datajpa.DiaryRepository;
+import com.shinhan.shbhack.ijoa.domain.diary.repository.datajpa.DiaryShareRepository;
 import com.shinhan.shbhack.ijoa.domain.diary.repository.query.DiaryQueryRepository;
 import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
 import com.shinhan.shbhack.ijoa.domain.member.repository.datajpa.MemberRepository;
@@ -16,11 +20,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
@@ -28,9 +36,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class DiaryService {
     private final DiaryRepository diaryRepository;
+    private final DiaryShareRepository diaryShareRepository;
     private final DiaryQueryRepository diaryQueryRepository;
     private final MemberRepository memberRepository;
     private final FileStore fileStore;
+    private Map<Long, LocalDateTime> checkExpire = new ConcurrentHashMap<>();
     public void writeDiary(DiaryCreateServiceRequest diaryCreateServiceRequest){
         try{
             Long memberId = Long.parseLong(diaryCreateServiceRequest.getMemberId());
@@ -44,6 +54,14 @@ public class DiaryService {
                 diaryImageList.add(DiaryImage.of(uploadFile, newDiary));
             } // 다이어리 이미지 객체 생성
             newDiary.setImages(diaryImageList); // 다이어리에 이미지 리스트 지정
+
+            MultipartFile recordInfo = diaryCreateServiceRequest.getRecord();
+            UploadFile diaryRecord = null;
+            if(recordInfo != null && !recordInfo.isEmpty()){
+                diaryRecord = fileStore.storeFile(recordInfo);
+                newDiary.setRecord(DiaryRecord.of(diaryRecord, newDiary));
+
+            }
             diaryRepository.save(newDiary);
 
         } catch (IOException e) {
@@ -61,7 +79,77 @@ public class DiaryService {
         log.info("다이어리 읽기, diaryId : "+diaryId);
         DiaryDetailResponse result = diaryQueryRepository.findDetailById(diaryId);
         List<DiaryImageResponse> diaryImageResponseList = diaryQueryRepository.findImagesById(diaryId);
+        DiaryRecordResponse diaryRecordResponse = diaryQueryRepository.findRecordById(diaryId);
         result.setImages(diaryImageResponseList);
+        result.setRecord(diaryRecordResponse);
         return result;
+    }
+
+    public void modifyDiary(DiaryCreateServiceRequest diaryCreateServiceRequest, Long diaryId){
+        try{
+            Diary modifyDiary = diaryRepository.findById(diaryId).orElseThrow(()-> new RuntimeException("일기 찾기 실패"));
+
+            modifyDiary.setTitle(diaryCreateServiceRequest.getTitle());
+            modifyDiary.setEmotion(diaryCreateServiceRequest.getEmotion());
+            modifyDiary.setContent(diaryCreateServiceRequest.getContent());
+            modifyDiary.setDiary_date(diaryCreateServiceRequest.getDate());
+            List<UploadFile> fileInfos = fileStore.storeFiles(diaryCreateServiceRequest.getPhoto());
+            List<DiaryImage> diaryImageList = new ArrayList<>();
+            for(UploadFile uploadFile : fileInfos){
+                diaryImageList.add(DiaryImage.of(uploadFile, modifyDiary));
+            } // 다이어리 이미지 객체 생성
+            modifyDiary.setImages(diaryImageList); // 다이어리에 이미지 리스트 지정
+
+            MultipartFile recordInfo = diaryCreateServiceRequest.getRecord();
+            UploadFile diaryRecord = null;
+            if(recordInfo != null && !recordInfo.isEmpty()){
+                diaryRecord = fileStore.storeFile(recordInfo);
+                modifyDiary.setRecord(DiaryRecord.of(diaryRecord, modifyDiary));
+
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public void deleteDiary(Long diaryId){
+        diaryRepository.deleteById(diaryId);
+    }
+
+    public void shareDiary(Long diaryId){
+//        Diary toShareDiary = diaryRepository.findById(diaryId).orElseThrow(()-> new RuntimeException("일기 찾기 실패"));
+//        LocalDateTime nowTime = LocalDateTime.now();
+//
+//        LocalDateTime expireTime = nowTime.plusMinutes(5);
+//        DiaryShare diaryShare = DiaryShare.of(toShareDiary, expireTime);
+//        diaryShareRepository.save(diaryShare);
+        LocalDateTime nowTime = LocalDateTime.now();
+
+        LocalDateTime expireTime = nowTime.plusMinutes(5);
+
+        if(checkExpire.get(diaryId) ==null){ // 공유 아닌 상태
+            checkExpire.put(diaryId, expireTime); // 시간 삽입
+        }else{ // 공유했던 값이 있을 때
+            checkExpire.replace(diaryId, expireTime); // 새로운 시간으로 갱신
+        }
+    }
+
+    public DiaryDetailResponse readShareDiary(Long diaryId){
+        LocalDateTime nowTime = LocalDateTime.now();
+        if(checkExpire.get(diaryId) ==null){ // 공유 아닌 상태
+            return null;
+        }else{ // 공유했던 값이 있을 때
+            if(checkExpire.get(diaryId).isAfter(nowTime)){ // 만료 안되었을 때
+                log.info("다이어리 읽기, diaryId : "+diaryId);
+                DiaryDetailResponse result = diaryQueryRepository.findDetailById(diaryId);
+                List<DiaryImageResponse> diaryImageResponseList = diaryQueryRepository.findImagesById(diaryId);
+                DiaryRecordResponse diaryRecordResponse = diaryQueryRepository.findRecordById(diaryId);
+                result.setImages(diaryImageResponseList);
+                result.setRecord(diaryRecordResponse);
+                return result;
+            }else{
+                return null;
+            }
+        }
     }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/request/DiaryCreateServiceRequest.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/request/DiaryCreateServiceRequest.java
@@ -22,6 +22,7 @@ public class DiaryCreateServiceRequest {
     private String content;
     private LocalDate date;
     private List<MultipartFile> photo;
+    private MultipartFile record;
 
     public DiaryCreateServiceRequest(DiaryCreateRequest diaryCreateRequest) {
         this.memberId = diaryCreateRequest.getMemberId();
@@ -30,5 +31,6 @@ public class DiaryCreateServiceRequest {
         this.content = diaryCreateRequest.getContent();
         this.date = diaryCreateRequest.getDate();
         this.photo = diaryCreateRequest.getPhoto();
+        this.record = diaryCreateRequest.getRecord();
     }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/response/DiaryDetailResponse.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/response/DiaryDetailResponse.java
@@ -1,6 +1,7 @@
 package com.shinhan.shbhack.ijoa.api.service.diary.dto.response;
 
 import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryImage;
+import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryRecord;
 import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryShare;
 import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
 import lombok.Getter;
@@ -27,6 +28,8 @@ public class DiaryDetailResponse {
     private Long diaryId;
     private String title;
     private String content;
+    private String emotion;
     private LocalDate diary_date;
     private List<DiaryImageResponse> images;
+    private DiaryRecordResponse record;
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/response/DiaryRecordResponse.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/api/service/diary/dto/response/DiaryRecordResponse.java
@@ -1,0 +1,14 @@
+package com.shinhan.shbhack.ijoa.api.service.diary.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PUBLIC;
+
+@Getter
+@NoArgsConstructor(access = PUBLIC)
+public class DiaryRecordResponse {
+    private Long diaryRecordId;
+    private String uploadFileName;
+    private String storeFileName;
+}

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/Diary.java
@@ -40,14 +40,17 @@ public class Diary extends BaseEntity {
     private String content;
 
     @NotNull
+    private String emotion;
+
+    @NotNull
     private LocalDate diary_date;
 
     @OneToMany(mappedBy = "diary")
     private List<DiaryImage> images;
 
-    @OneToMany(mappedBy = "diary")
-    private List<DiaryShare> shares;
 
+    @OneToOne(mappedBy = "diary")
+    private DiaryRecord record;
 
     public static Diary of(DiaryCreateServiceRequest diaryCreateServiceRequest, Member member){
         Diary diary = new Diary();
@@ -55,7 +58,7 @@ public class Diary extends BaseEntity {
         diary.setTitle(diaryCreateServiceRequest.getTitle());
         diary.setDiary_date(diaryCreateServiceRequest.getDate());
         diary.setContent(diaryCreateServiceRequest.getContent());
-//        diary.setImages(images);
+        diary.setEmotion(diaryCreateServiceRequest.getEmotion());
         return diary;
     }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/DiaryRecord.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/DiaryRecord.java
@@ -1,0 +1,43 @@
+package com.shinhan.shbhack.ijoa.domain.diary.entity;
+
+import com.shinhan.shbhack.ijoa.common.util.file.UploadFile;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class DiaryRecord {
+    @Id
+    @Column(name = "diary_record_id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Long diaryRecordId;
+
+    @NotNull
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @NotNull
+    private String uploadFileName;
+
+    @NotNull
+    private String storeFileName;
+
+    public static DiaryRecord of(UploadFile fileInfos, Diary diary){
+        DiaryRecord diaryRecord = new DiaryRecord();
+        diaryRecord.setDiary(diary);
+        diaryRecord.setUploadFileName(fileInfos.getUploadFileName());
+        diaryRecord.setStoreFileName(fileInfos.getStoreFileName());
+        return diaryRecord;
+    }
+}

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/DiaryShare.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/entity/DiaryShare.java
@@ -1,19 +1,24 @@
 package com.shinhan.shbhack.ijoa.domain.diary.entity;
 
+import com.shinhan.shbhack.ijoa.common.util.file.UploadFile;
 import com.shinhan.shbhack.ijoa.domain.BaseEntity;
 import com.shinhan.shbhack.ijoa.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiaryShare extends BaseEntity {
     @Id
@@ -21,14 +26,19 @@ public class DiaryShare extends BaseEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Long diaryShareId;
 
-    @NotNull
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name="member_id")
-    private Member member;
 
     @NotNull
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name="diary_id")
     private Diary diary;
 
+    @NotNull
+    private LocalDateTime expireTime;
+
+    public static DiaryShare of(Diary toShareDiary, LocalDateTime expireTime){
+        DiaryShare diaryShare = new DiaryShare();
+        diaryShare.setDiary(toShareDiary);
+        diaryShare.setExpireTime(expireTime);
+        return diaryShare;
+    }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/datajpa/DiaryRecordRepository.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/datajpa/DiaryRecordRepository.java
@@ -1,0 +1,7 @@
+package com.shinhan.shbhack.ijoa.domain.diary.repository.datajpa;
+
+import com.shinhan.shbhack.ijoa.domain.diary.entity.DiaryRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryRecordRepository extends JpaRepository<DiaryRecord, Long> {
+}

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/query/DiaryQueryRepository.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/diary/repository/query/DiaryQueryRepository.java
@@ -10,8 +10,10 @@ import static com.shinhan.shbhack.ijoa.domain.diary.entity.QDiary.diary;
 
 import static com.shinhan.shbhack.ijoa.domain.member.entity.QMember.member;
 import static com.shinhan.shbhack.ijoa.domain.diary.entity.QDiaryImage.diaryImage;
+import static com.shinhan.shbhack.ijoa.domain.diary.entity.QDiaryRecord.diaryRecord;
 
 
+import com.shinhan.shbhack.ijoa.api.service.diary.dto.response.DiaryRecordResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -29,12 +31,17 @@ public class DiaryQueryRepository {
     }
 
     public DiaryDetailResponse findDetailById(Long diaryId){
-        return queryFactory.select(Projections.fields(DiaryDetailResponse.class, diary.diaryId, diary.title, diary.content, diary.diary_date)).from(diary)
+        return queryFactory.select(Projections.fields(DiaryDetailResponse.class, diary.diaryId, diary.title, diary.content, diary.diary_date, diary.emotion)).from(diary)
                 .where(diary.diaryId.eq(diaryId)).fetchOne();
     }
 
     public List<DiaryImageResponse> findImagesById(Long diaryId){
         return queryFactory.select(Projections.fields(DiaryImageResponse.class, diaryImage.diaryImageId, diaryImage.uploadFileName, diaryImage.storeFileName)).from(diaryImage)
                 .join(diaryImage.diary, diary).where(diaryImage.diary.diaryId.eq(diaryId)).fetch();
+    }
+
+    public DiaryRecordResponse findRecordById(Long diaryId){
+        return queryFactory.select(Projections.fields(DiaryRecordResponse.class, diaryRecord.diaryRecordId, diaryRecord.uploadFileName, diaryRecord.storeFileName)).from(diaryRecord)
+                .join(diaryRecord.diary, diary).where(diaryRecord.diary.diaryId.eq(diaryId)).fetchOne();
     }
 }

--- a/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/shinhan/shbhack/ijoa/domain/member/entity/Member.java
@@ -101,13 +101,11 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
     private List<Diary> diaries = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
-    private List<DiaryShare> diaryShares = new ArrayList<>();
 
 
 
     @Builder
-    public Member(Long id, String name, String nickname, String email, String password, String account, String address, LocalDate birthDate, Gender gender, MemberRole memberRole, ActivateStatus activateStatus, List<Family> children, List<Family> parents, List<Friend> firstFriends, List<Friend> secondFriends, List<Mission> writers, List<Mission> challengers, List<Notification> receivers, List<Notification> senders, ProfileImage profileImage, List<Diary> diaries, List<DiaryShare> diaryShares) {
+    public Member(Long id, String name, String nickname, String email, String password, String account, String address, LocalDate birthDate, Gender gender, MemberRole memberRole, ActivateStatus activateStatus, List<Family> children, List<Family> parents, List<Friend> firstFriends, List<Friend> secondFriends, List<Mission> writers, List<Mission> challengers, List<Notification> receivers, List<Notification> senders, ProfileImage profileImage, List<Diary> diaries) {
         this.id = id;
         this.name = name;
         this.nickname = nickname;
@@ -129,6 +127,5 @@ public class Member extends BaseEntity {
         this.senders = senders;
         this.profileImage = profileImage;
         this.diaries = diaries;
-        this.diaryShares = diaryShares;
     }
 }


### PR DESCRIPTION
## 구현 기능

-   일기 작성
-  일기 리스트
- 일기 상세정보 
- 일기 공유하기
- 일기 수정하기
- 일기 삭제하기
- 공유된 일기 읽기 : '일기 공유하기' 요청을 사전에 해야 가능하며 5분동안 읽을 수 있음

## 논의하고 싶은 내용

-   현재 프론트엔드에서 테스트를 못해본 부분이 있습니다.


Close #31 
